### PR TITLE
Updating to have better non image file handling.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,6 @@ app:
     S3_HOST:
     PUBLIC:
     FOLDER:
+    ALLOWED_EXTENSIONS:
   ports:
     - '8080'

--- a/views/multi.js
+++ b/views/multi.js
@@ -14,9 +14,10 @@ Dropzone.options.uploader = {
 
     hide(findOne('#uploader'));
 
+    const divStyle = (obj.isImage) ? `background-image: url(${imageUrl});` : '';
     const img = `
       <div class="image-container">
-        <div class="image" style="background-image: url(${imageUrl});"></div>
+        <div class="image" style="${divStyle}"></div>
         <input readonly value="${imageUrl}" onfocus="this.select();"/>
       </div>
     `;

--- a/views/single.js
+++ b/views/single.js
@@ -22,6 +22,18 @@ const handleImage = function(imgSrc) {
   show('#clear');
 };
 
+const handleFile = function(fileSrc) {
+  hide(['#uploader', '#progress', '#status']);
+  const results = findOne('#results');
+  results.innerHTML = fileSrc;
+  styles(results, {
+    display: 'block',
+    lineHeight: '100vh',
+    textAlign: 'center'
+  });
+  show('#clear');
+};
+
 Dropzone.options.uploader = {
   init() {
     dropzone = this;
@@ -56,9 +68,12 @@ Dropzone.options.uploader = {
 
     const response = file.xhr.response;
     const obj = JSON.parse(response);
-    const imageUrl = obj.location;
-    handleImage(imageUrl);
-
+    const fileUrl = obj.location;
+    if (obj.isImage) {
+      handleImage(fileUrl);
+    } else {
+      handleFile(fileUrl);
+    }
     event.type = 'complete';
     event.data = obj;
 


### PR DESCRIPTION
Currently, there is very poor handling of non-image uploads. On the single upload page... any non images simply disappear without any success handlers. On the multi upload page... non images are treated like images and are loaded as backgrounds to divs. And the upload handler processes all uploads like images regardless of their actual file type (ie. tries to resize etc...).

This PR attempts to remedy some of those situations.